### PR TITLE
Add a check to see if the other half of a crate is present, therefore preventing a crash

### DIFF
--- a/src/main/java/dev/hail/create_fantasizing/block/crate/AbstractDoubleStorageEntity.java
+++ b/src/main/java/dev/hail/create_fantasizing/block/crate/AbstractDoubleStorageEntity.java
@@ -45,7 +45,7 @@ public abstract class AbstractDoubleStorageEntity extends CrateBlockEntity imple
     }
 
     public boolean isDoubleCrate() {
-        return getBlockState().getValue(CRATE_TYPE).isDouble();
+        return getBlockState().getValue(CRATE_TYPE).isDouble() && getOtherCrate() != null;
     }
 
     public boolean isSecondaryCrate() {


### PR DESCRIPTION
There exists a crash condition where if the other half of a double crate gets deleted, a player looking at the first half with goggles on will crash due to a missing null check [here](https://github.com/Ironnoob73/Create-FantasizingAgain/blob/187e740901f613db782a443e88d469a4660e376a/src/main/java/dev/hail/create_fantasizing/block/crate/AbstractCrateEntity.java#L111).